### PR TITLE
Scatter highlight tests

### DIFF
--- a/src/ScottPlot/plottables/IHighlightable.cs
+++ b/src/ScottPlot/plottables/IHighlightable.cs
@@ -4,11 +4,11 @@ using System.Text;
 
 namespace ScottPlot.plottables
 {
-	interface IHighlightable
-	{
-		void HighlightPoint(int index);
-		void HighlightPointNearest(double x);
-		void HighlightPointNearest(double x, double y);
-		void HighlightClear();
-	}
+    interface IHighlightable
+    {
+        void HighlightPoint(int index);
+        void HighlightPointNearest(double x);
+        void HighlightPointNearest(double x, double y);
+        void HighlightClear();
+    }
 }

--- a/src/ScottPlot/plottables/PlottableScatter.cs
+++ b/src/ScottPlot/plottables/PlottableScatter.cs
@@ -9,224 +9,224 @@ using ScottPlot.Drawing;
 
 namespace ScottPlot
 {
-	public class PlottableScatter : Plottable, IExportable
-	{
-		public double[] xs;
-		public double[] ys;
-		public double[] errorX;
-		public double[] errorY;
-		public double lineWidth;
-		public float errorLineWidth;
-		public float errorCapSize;
-		public float markerSize;
-		public bool stepDisplay;
+    public class PlottableScatter : Plottable, IExportable
+    {
+        public double[] xs;
+        public double[] ys;
+        public double[] errorX;
+        public double[] errorY;
+        public double lineWidth;
+        public float errorLineWidth;
+        public float errorCapSize;
+        public float markerSize;
+        public bool stepDisplay;
 
-		public MarkerShape markerShape;
-		public Color color;
-		public LineStyle lineStyle;
-		public string label;
+        public MarkerShape markerShape;
+        public Color color;
+        public LineStyle lineStyle;
+        public string label;
 
-		public Pen penLine;
-		private Pen penLineError;
+        public Pen penLine;
+        private Pen penLineError;
 
-		public PlottableScatter(double[] xs, double[] ys, Color color, double lineWidth, double markerSize, string label,
-			double[] errorX, double[] errorY, double errorLineWidth, double errorCapSize, bool stepDisplay, MarkerShape markerShape, LineStyle lineStyle)
-		{
+        public PlottableScatter(double[] xs, double[] ys, Color color, double lineWidth, double markerSize, string label,
+            double[] errorX, double[] errorY, double errorLineWidth, double errorCapSize, bool stepDisplay, MarkerShape markerShape, LineStyle lineStyle)
+        {
 
-			if ((xs == null) || (ys == null))
-				throw new ArgumentException("X and Y data cannot be null");
+            if ((xs == null) || (ys == null))
+                throw new ArgumentException("X and Y data cannot be null");
 
-			if ((xs.Length == 0) || (ys.Length == 0))
-				throw new ArgumentException("xs and ys must have at least one element");
+            if ((xs.Length == 0) || (ys.Length == 0))
+                throw new ArgumentException("xs and ys must have at least one element");
 
-			if (xs.Length != ys.Length)
-				throw new ArgumentException("Xs and Ys must have same length");
+            if (xs.Length != ys.Length)
+                throw new ArgumentException("Xs and Ys must have same length");
 
-			if (errorY != null)
-				for (int i = 0; i < errorY.Length; i++)
-					if (errorY[i] < 0)
-						errorY[i] = -errorY[i];
+            if (errorY != null)
+                for (int i = 0; i < errorY.Length; i++)
+                    if (errorY[i] < 0)
+                        errorY[i] = -errorY[i];
 
-			if (errorX != null)
-				for (int i = 0; i < errorX.Length; i++)
-					if (errorX[i] < 0)
-						errorX[i] = -errorX[i];
+            if (errorX != null)
+                for (int i = 0; i < errorX.Length; i++)
+                    if (errorX[i] < 0)
+                        errorX[i] = -errorX[i];
 
-			this.xs = xs;
-			this.ys = ys;
-			this.color = color;
-			this.lineWidth = lineWidth;
-			this.markerSize = (float)markerSize;
-			this.label = label;
-			this.errorX = errorX;
-			this.errorY = errorY;
-			this.errorLineWidth = (float)errorLineWidth;
-			this.errorCapSize = (float)errorCapSize;
-			this.stepDisplay = stepDisplay;
-			this.markerShape = markerShape;
-			this.lineStyle = lineStyle;
+            this.xs = xs;
+            this.ys = ys;
+            this.color = color;
+            this.lineWidth = lineWidth;
+            this.markerSize = (float)markerSize;
+            this.label = label;
+            this.errorX = errorX;
+            this.errorY = errorY;
+            this.errorLineWidth = (float)errorLineWidth;
+            this.errorCapSize = (float)errorCapSize;
+            this.stepDisplay = stepDisplay;
+            this.markerShape = markerShape;
+            this.lineStyle = lineStyle;
 
-			if (xs.Length != ys.Length)
-				throw new ArgumentException("X and Y arrays must have the same length");
+            if (xs.Length != ys.Length)
+                throw new ArgumentException("X and Y arrays must have the same length");
 
-			if ((errorX != null) && (xs.Length != errorX.Length))
-				throw new ArgumentException("errorX must be the same length as the original data");
+            if ((errorX != null) && (xs.Length != errorX.Length))
+                throw new ArgumentException("errorX must be the same length as the original data");
 
-			if ((errorY != null) && (xs.Length != errorY.Length))
-				throw new ArgumentException("errorY must be the same length as the original data");
+            if ((errorY != null) && (xs.Length != errorY.Length))
+                throw new ArgumentException("errorY must be the same length as the original data");
 
-			penLine = GDI.Pen(color, lineWidth, lineStyle, true);
-			penLineError = GDI.Pen(color, errorLineWidth, LineStyle.Solid, true);
-		}
+            penLine = GDI.Pen(color, lineWidth, lineStyle, true);
+            penLineError = GDI.Pen(color, errorLineWidth, LineStyle.Solid, true);
+        }
 
-		public override string ToString()
-		{
-			string label = string.IsNullOrWhiteSpace(this.label) ? "" : $" ({this.label})";
-			return $"PlottableScatter{label} with {GetPointCount()} points";
-		}
+        public override string ToString()
+        {
+            string label = string.IsNullOrWhiteSpace(this.label) ? "" : $" ({this.label})";
+            return $"PlottableScatter{label} with {GetPointCount()} points";
+        }
 
-		public override Config.AxisLimits2D GetLimits()
-		{
-			double[] limits = new double[4];
+        public override Config.AxisLimits2D GetLimits()
+        {
+            double[] limits = new double[4];
 
-			if (errorX == null)
-			{
-				limits[0] = xs.Min();
-				limits[1] = xs.Max();
-			}
-			else
-			{
-				limits[0] = xs[0] - errorX[0];
-				limits[1] = xs[0] + errorX[0];
-				for (int i = 1; i < xs.Length; i++)
-				{
-					if (xs[i] - errorX[i] < limits[0])
-						limits[0] = xs[i] - errorX[i];
-					if (xs[i] + errorX[i] > limits[0])
-						limits[1] = xs[i] + errorX[i];
-				}
-			}
+            if (errorX == null)
+            {
+                limits[0] = xs.Min();
+                limits[1] = xs.Max();
+            }
+            else
+            {
+                limits[0] = xs[0] - errorX[0];
+                limits[1] = xs[0] + errorX[0];
+                for (int i = 1; i < xs.Length; i++)
+                {
+                    if (xs[i] - errorX[i] < limits[0])
+                        limits[0] = xs[i] - errorX[i];
+                    if (xs[i] + errorX[i] > limits[0])
+                        limits[1] = xs[i] + errorX[i];
+                }
+            }
 
-			if (errorY == null)
-			{
-				limits[2] = ys.Min();
-				limits[3] = ys.Max();
-			}
-			else
-			{
-				limits[2] = ys[0] - errorY[0];
-				limits[3] = ys[0] + errorY[0];
-				for (int i = 1; i < ys.Length; i++)
-				{
-					if (ys[i] - errorY[i] < limits[2])
-						limits[2] = ys[i] - errorY[i];
-					if (ys[i] + errorY[i] > limits[3])
-						limits[3] = ys[i] + errorY[i];
-				}
-			}
+            if (errorY == null)
+            {
+                limits[2] = ys.Min();
+                limits[3] = ys.Max();
+            }
+            else
+            {
+                limits[2] = ys[0] - errorY[0];
+                limits[3] = ys[0] + errorY[0];
+                for (int i = 1; i < ys.Length; i++)
+                {
+                    if (ys[i] - errorY[i] < limits[2])
+                        limits[2] = ys[i] - errorY[i];
+                    if (ys[i] + errorY[i] > limits[3])
+                        limits[3] = ys[i] + errorY[i];
+                }
+            }
 
-			// TODO: use features of 2d axis
-			return new Config.AxisLimits2D(limits);
-		}
+            // TODO: use features of 2d axis
+            return new Config.AxisLimits2D(limits);
+        }
 
-		protected virtual void DrawPoint(Settings settings, List<PointF>  points, int i)
-		{
-			MarkerTools.DrawMarker(settings.gfxData, points[i], markerShape, markerSize, color);
-		}
+        protected virtual void DrawPoint(Settings settings, List<PointF> points, int i)
+        {
+            MarkerTools.DrawMarker(settings.gfxData, points[i], markerShape, markerSize, color);
+        }
 
-		public override void Render(Settings settings)
-		{
-			penLine.Color = color;
-			penLine.Width = (float)lineWidth;
+        public override void Render(Settings settings)
+        {
+            penLine.Color = color;
+            penLine.Width = (float)lineWidth;
 
-			// create a List of only valid points
-			List<PointF> points = new List<PointF>(xs.Length);
-			for (int i = 0; i < xs.Length; i++)
-				if (!double.IsNaN(xs[i]) && !double.IsNaN(ys[i]))
-					points.Add(settings.GetPixel(xs[i], ys[i]));
+            // create a List of only valid points
+            List<PointF> points = new List<PointF>(xs.Length);
+            for (int i = 0; i < xs.Length; i++)
+                if (!double.IsNaN(xs[i]) && !double.IsNaN(ys[i]))
+                    points.Add(settings.GetPixel(xs[i], ys[i]));
 
-			// draw Y errorbars
-			if (errorY != null)
-			{
-				for (int i = 0; i < points.Count; i++)
-				{
-					PointF errorBelow = settings.GetPixel(xs[i], ys[i] - errorY[i]);
-					PointF errorAbove = settings.GetPixel(xs[i], ys[i] + errorY[i]);
-					float xCenter = errorBelow.X;
-					float yTop = errorAbove.Y;
-					float yBot = errorBelow.Y;
-					settings.gfxData.DrawLine(penLineError, xCenter, yBot, xCenter, yTop);
-					settings.gfxData.DrawLine(penLineError, xCenter - errorCapSize, yBot, xCenter + errorCapSize, yBot);
-					settings.gfxData.DrawLine(penLineError, xCenter - errorCapSize, yTop, xCenter + errorCapSize, yTop);
-				}
-			}
+            // draw Y errorbars
+            if (errorY != null)
+            {
+                for (int i = 0; i < points.Count; i++)
+                {
+                    PointF errorBelow = settings.GetPixel(xs[i], ys[i] - errorY[i]);
+                    PointF errorAbove = settings.GetPixel(xs[i], ys[i] + errorY[i]);
+                    float xCenter = errorBelow.X;
+                    float yTop = errorAbove.Y;
+                    float yBot = errorBelow.Y;
+                    settings.gfxData.DrawLine(penLineError, xCenter, yBot, xCenter, yTop);
+                    settings.gfxData.DrawLine(penLineError, xCenter - errorCapSize, yBot, xCenter + errorCapSize, yBot);
+                    settings.gfxData.DrawLine(penLineError, xCenter - errorCapSize, yTop, xCenter + errorCapSize, yTop);
+                }
+            }
 
-			// draw X errorbars
-			if (errorX != null)
-			{
-				for (int i = 0; i < points.Count; i++)
-				{
-					PointF errorLeft = settings.GetPixel(xs[i] - errorX[i], ys[i]);
-					PointF errorRight = settings.GetPixel(xs[i] + errorX[i], ys[i]);
-					float yCenter = errorLeft.Y;
-					float xLeft = errorLeft.X;
-					float xRight = errorRight.X;
-					settings.gfxData.DrawLine(penLineError, xLeft, yCenter, xRight, yCenter);
-					settings.gfxData.DrawLine(penLineError, xLeft, yCenter - errorCapSize, xLeft, yCenter + errorCapSize);
-					settings.gfxData.DrawLine(penLineError, xRight, yCenter - errorCapSize, xRight, yCenter + errorCapSize);
-				}
-			}
+            // draw X errorbars
+            if (errorX != null)
+            {
+                for (int i = 0; i < points.Count; i++)
+                {
+                    PointF errorLeft = settings.GetPixel(xs[i] - errorX[i], ys[i]);
+                    PointF errorRight = settings.GetPixel(xs[i] + errorX[i], ys[i]);
+                    float yCenter = errorLeft.Y;
+                    float xLeft = errorLeft.X;
+                    float xRight = errorRight.X;
+                    settings.gfxData.DrawLine(penLineError, xLeft, yCenter, xRight, yCenter);
+                    settings.gfxData.DrawLine(penLineError, xLeft, yCenter - errorCapSize, xLeft, yCenter + errorCapSize);
+                    settings.gfxData.DrawLine(penLineError, xRight, yCenter - errorCapSize, xRight, yCenter + errorCapSize);
+                }
+            }
 
-			// draw the lines connecting points
-			if (penLine.Width > 0 && points.Count > 1)
-			{
-				if (stepDisplay)
-				{
-					List<PointF> pointsStep = new List<PointF>(points.Count * 2);
-					for (int i = 0; i < points.Count - 1; i++)
-					{
-						pointsStep.Add(points[i]);
-						pointsStep.Add(new PointF(points[i + 1].X, points[i].Y));
-					}
-					pointsStep.Add(points[points.Count - 1]);
-					settings.gfxData.DrawLines(penLine, pointsStep.ToArray());
-				}
-				else
-				{
-					settings.gfxData.DrawLines(penLine, points.ToArray());
-				}
-			}
+            // draw the lines connecting points
+            if (penLine.Width > 0 && points.Count > 1)
+            {
+                if (stepDisplay)
+                {
+                    List<PointF> pointsStep = new List<PointF>(points.Count * 2);
+                    for (int i = 0; i < points.Count - 1; i++)
+                    {
+                        pointsStep.Add(points[i]);
+                        pointsStep.Add(new PointF(points[i + 1].X, points[i].Y));
+                    }
+                    pointsStep.Add(points[points.Count - 1]);
+                    settings.gfxData.DrawLines(penLine, pointsStep.ToArray());
+                }
+                else
+                {
+                    settings.gfxData.DrawLines(penLine, points.ToArray());
+                }
+            }
 
-			// draw a marker at each point
-			if ((markerSize > 0) && (markerShape != MarkerShape.none))
-				for (int i = 0; i < points.Count; i++)
-					DrawPoint(settings, points, i);
+            // draw a marker at each point
+            if ((markerSize > 0) && (markerShape != MarkerShape.none))
+                for (int i = 0; i < points.Count; i++)
+                    DrawPoint(settings, points, i);
 
-		}
+        }
 
-		public void SaveCSV(string filePath, string delimiter = ", ", string separator = "\n")
-		{
-			System.IO.File.WriteAllText(filePath, GetCSV(delimiter, separator));
-		}
+        public void SaveCSV(string filePath, string delimiter = ", ", string separator = "\n")
+        {
+            System.IO.File.WriteAllText(filePath, GetCSV(delimiter, separator));
+        }
 
-		public string GetCSV(string delimiter = ", ", string separator = "\n")
-		{
-			StringBuilder csv = new StringBuilder();
-			for (int i = 0; i < ys.Length; i++)
-				csv.AppendFormat("{0}{1}{2}{3}", xs[i], delimiter, ys[i], separator);
-			return csv.ToString();
-		}
+        public string GetCSV(string delimiter = ", ", string separator = "\n")
+        {
+            StringBuilder csv = new StringBuilder();
+            for (int i = 0; i < ys.Length; i++)
+                csv.AppendFormat("{0}{1}{2}{3}", xs[i], delimiter, ys[i], separator);
+            return csv.ToString();
+        }
 
-		public override int GetPointCount()
-		{
-			return ys.Length;
-		}
+        public override int GetPointCount()
+        {
+            return ys.Length;
+        }
 
-		public override LegendItem[] GetLegendItems()
-		{
-			// TODO: determine how to respect line width in legend
-			var singleLegendItem = new Config.LegendItem(label, color, lineStyle, lineWidth, markerShape, markerSize);
-			return new LegendItem[] { singleLegendItem };
-		}
-	}
+        public override LegendItem[] GetLegendItems()
+        {
+            // TODO: determine how to respect line width in legend
+            var singleLegendItem = new Config.LegendItem(label, color, lineStyle, lineWidth, markerShape, markerSize);
+            return new LegendItem[] { singleLegendItem };
+        }
+    }
 }

--- a/src/ScottPlot/plottables/PlottableScatterHighlight.cs
+++ b/src/ScottPlot/plottables/PlottableScatterHighlight.cs
@@ -13,7 +13,7 @@ namespace ScottPlot
 {
     public class PlottableScatterHighlight : PlottableScatter, IExportable, IHighlightable
     {
-        private List<int> highlightedIndexes;
+        protected List<int> highlightedIndexes;
         public MarkerShape highlightedShape;
         public float highlightedMarkerSize;
         public Color highlightedColor;

--- a/tests/Plot/ScatterHighlightTests.cs
+++ b/tests/Plot/ScatterHighlightTests.cs
@@ -41,6 +41,7 @@ namespace ScottPlotTests.Plot
             plottable.HighlightClear();
             Assert.IsEmpty(plottable.HighlightedIndexes);
         }
+
         [TestCase(0)]
         [TestCase(1)]
         [TestCase(2)]
@@ -118,7 +119,6 @@ namespace ScottPlotTests.Plot
             Assert.AreEqual(1, plottable.HighlightedIndexes.Count);
             Assert.AreEqual(expectedIndex, plottable.HighlightedIndexes[0]);
         }
-
 
         [TestCase(0.1, 0, 0)]
         [TestCase(0.0, 0.1, 1)]

--- a/tests/Plot/ScatterHighlightTests.cs
+++ b/tests/Plot/ScatterHighlightTests.cs
@@ -1,0 +1,179 @@
+﻿using NUnit.Framework;
+using ScottPlot;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace ScottPlotTests.Plot
+{
+    public class PlottableScatterHighlightTestable : PlottableScatterHighlight
+    {
+        public PlottableScatterHighlightTestable(double[] xs, double[] ys, Color color, double lineWidth, double markerSize, string label,
+            double[] errorX, double[] errorY, double errorLineWidth, double errorCapSize, bool stepDisplay, MarkerShape markerShape, LineStyle lineStyle, MarkerShape highlightedShape, Color highlightedColor, double highlightedMarkerSize)
+            : base(xs, ys, color, lineWidth, markerSize, label, errorX, errorY, errorLineWidth, errorCapSize, stepDisplay, markerShape, lineStyle, highlightedShape, highlightedColor, highlightedMarkerSize)
+        {
+        }
+        public List<int> HighlightedIndexes
+        {
+            get => highlightedIndexes;
+            set => highlightedIndexes = value;
+        }
+    }
+
+    [TestFixture]
+    public class PlottableScatterHighlightTests
+    {
+        private PlottableScatterHighlightTestable InitWithTestValues()
+        {
+            double[] xs = new double[] { 1.0, 2.0, 3.0, 4.0 };
+            double[] ys = new double[] { 1.0, 2.0, 3.0, 4.0 };
+            double[] error = new double[] { 0.1, 0.1, 0.1, 0.1 };
+            return new PlottableScatterHighlightTestable(xs, ys, Color.Red, 1, 1, "Test", error, error, 1, 1, false, MarkerShape.openCircle, LineStyle.Solid, MarkerShape.openSquare, Color.Green, 10);
+        }
+
+        [Test]
+        public void HighlightClear_CallOnNotEmpty_ClearHighlightedIndexes()
+        {
+            var plottable = InitWithTestValues();
+            plottable.HighlightedIndexes = new List<int>() { 1, 2, 3, 4, 5 };
+
+            Assert.IsNotEmpty(plottable.HighlightedIndexes);
+            plottable.HighlightClear();
+            Assert.IsEmpty(plottable.HighlightedIndexes);
+        }
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(4)]
+        public void HighlightPoint_ExistedIndexProvided_AddToHighlighted(int index)
+        {
+            var plottable = InitWithTestValues();
+            plottable.xs = new double[] { 1, 2, 3, 4, 5 };
+            plottable.ys = new double[] { 1, 2, 3, 4, 5 };
+
+            plottable.HighlightPoint(index);
+            Assert.AreEqual(plottable.HighlightedIndexes.Count, 1);
+            Assert.AreEqual(index, plottable.HighlightedIndexes[0]);
+        }
+
+        [TestCase(-5)]
+        [TestCase(-1)]
+        [TestCase(15)]
+        [TestCase(42)]
+        public void HighlightPoint_NonExistedIndexProvided_IndexAdded(int index)
+        {
+            var plottable = InitWithTestValues();
+            plottable.xs = new double[] { 1, 2, 3, 4, 5 };
+            plottable.ys = new double[] { 1, 2, 3, 4, 5 };
+
+            plottable.HighlightPoint(index);
+
+            Assert.AreEqual(plottable.HighlightedIndexes.Count, 1);
+            Assert.AreEqual(index, plottable.HighlightedIndexes[0]);
+        }
+
+        [TestCase(12)]
+        [TestCase(19)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(4)]
+        [TestCase(1)]
+        [TestCase(0)]
+        [TestCase(15)]
+        [TestCase(79)]
+        public void HighlightPoint_AddIndexToExistedList_KeepItSorted(int index)
+        {
+            var plottable = InitWithTestValues();
+            plottable.xs = Enumerable.Range(0, 100).Select(x => (double)x).ToArray();
+            plottable.ys = Enumerable.Range(0, 100).Select(x => (double)x).ToArray();
+
+            plottable.HighlightedIndexes = new List<int>() { 1, 3, 15, 42 };
+
+            List<int> expectedList = new List<int>();
+            expectedList.AddRange(plottable.HighlightedIndexes);
+            expectedList.Add(index);
+            expectedList.Sort();
+
+            plottable.HighlightPoint(index);
+
+            Assert.AreEqual(expectedList, plottable.HighlightedIndexes);
+        }
+
+        [TestCase(0, 3)]
+        [TestCase(-500, 0)]
+        [TestCase(1000, 6)]
+        [TestCase(0, 3)]
+        [TestCase(-0.4, 3)]
+        [TestCase(-0.6, 2)]
+        [TestCase(2, 4)]
+        [TestCase(2.0000001, 5)]
+        public void HighlightPointNearest_SomeXValues_NearestPointIndexAdded(double x, int expectedIndex)
+        {
+            var plottable = InitWithTestValues();
+            plottable.xs = new double[] { -3, -2, -1, 0, 1, 3, 5 };
+            plottable.ys = new double[] { 12, 3, -5, 0, 10, 0, 7 };
+
+            plottable.HighlightPointNearest(x);
+
+            Assert.AreEqual(1, plottable.HighlightedIndexes.Count);
+            Assert.AreEqual(expectedIndex, plottable.HighlightedIndexes[0]);
+        }
+
+
+        [TestCase(0.1, 0, 0)]
+        [TestCase(0.0, 0.1, 1)]
+        [TestCase(-0.1, 0.0, 2)]
+        [TestCase(0.0, -0.1, 3)]
+        [TestCase(1000, 1, 0)]
+        [TestCase(1, 1000, 1)]
+        public void HighlightPointNearest_SomeXYValues_NearestPointIndexAdded(double x, double y, int expectedIndex)
+        {
+            var plottable = InitWithTestValues();
+            plottable.xs = new double[] { 1, 0, -1, 0 };
+            plottable.ys = new double[] { 0, 1, 0, -1 };
+
+            plottable.HighlightPointNearest(x, y);
+
+            Assert.AreEqual(1, plottable.HighlightedIndexes.Count);
+            Assert.AreEqual(expectedIndex, plottable.HighlightedIndexes[0]);
+        }
+
+        [TestCase(-3, -3, 12)]
+        [TestCase(-500, -3, 12)]
+        [TestCase(1000, 5, 7)]
+        [TestCase(0, 0, 0)]
+        [TestCase(-0.4, 0, 0)]
+        [TestCase(-0.6, -1, -5)]
+        [TestCase(2, 1, 10)]
+        [TestCase(2.0000001, 3, 0)]
+        public void GetPointNearest_SomeXValues_ReturnNearestPoint(double x, double expectedX, double expectedY)
+        {
+            var plottable = InitWithTestValues();
+            plottable.xs = new double[] { -3, -2, -1, 0, 1, 3, 5 };
+            plottable.ys = new double[] { 12, 3, -5, 0, 10, 0, 7 };
+
+            var result = plottable.GetPointNearest(x);
+
+            Assert.AreEqual(expectedX, result.x, 0.01);
+            Assert.AreEqual(expectedY, result.y, 0.01);
+        }
+
+        [TestCase(0.1, 0, 1, 0)]
+        [TestCase(0.0, 0.1, 0, 1)]
+        [TestCase(-0.1, 0.0, -1, 0)]
+        [TestCase(0.0, -0.1, 0, -1)]
+        [TestCase(1000, 1, 1, 0)]
+        [TestCase(1, 1000, 0, 1)]
+        public void GetPointNearest_SomeXYValues_NearestPointIndexAdded(double x, double y, double expectedX, double expectedY)
+        {
+            var plottable = InitWithTestValues();
+            plottable.xs = new double[] { 1, 0, -1, 0 };
+            plottable.ys = new double[] { 0, 1, 0, -1 };
+
+            var result = plottable.GetPointNearest(x, y);
+
+            Assert.AreEqual(expectedX, result.x, 0.01);
+            Assert.AreEqual(expectedY, result.y, 0.01);
+        }
+    }
+}


### PR DESCRIPTION
**Purpose:**
Add unit tests for ScatterHighlight math.
Addtionaly replace tabs with spaces back in `IHighlightable.cs` and `PlottableScatter.cs`. VS don't show the difference, but github grabs it as changes.

I can't commit to you PR directly, but can make PR to you fork branch.

**New functionality (code):**
change `HighlightIndexes` signature from `private` to `protected`. This allow test its values in derived test class.

**New functionality (image):**
Only math of public api `IHighligtable` was tested.