### PR TITLE
Fix missed plotResize on LoadDemo,

### DIFF
--- a/src/ScottPlot.Avalonia/AvaPlotBackend.cs
+++ b/src/ScottPlot.Avalonia/AvaPlotBackend.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Text;
-using System.Threading.Tasks;
-using Avalonia.Controls;
+﻿using Avalonia.Controls;
 using Avalonia.VisualTree;
 using ScottPlot.Interactive;
-
+using System.Collections.Generic;
+using System.Drawing;
+using System.Threading.Tasks;
 using Ava = global::Avalonia;
 
 namespace ScottPlot.Avalonia
@@ -38,7 +35,7 @@ namespace ScottPlot.Avalonia
             {
                 // hide the version info
                 mainGrid.RowDefinitions[0].Height = new GridLength(0);
-                //CanvasPlot_SizeChanged(null, null);
+                CanvasSizeChanged((int)(view.Find<Canvas>("canvasPlot").Bounds.Width * dpiScaleOutput), (int)(view.Find<Canvas>("canvasPlot").Bounds.Height * dpiScaleOutput));
                 //dpiScaleInput = settings.gfxFigure.DpiX / 96; THIS IS ONLY NECESSARY ON WPF
                 dpiScaleOutput = settings.gfxFigure.DpiX / 96;
                 view.Find<StackPanel>("canvasDesigner").Background = view.transparentBrush;
@@ -46,6 +43,7 @@ namespace ScottPlot.Avalonia
             }
 
         }
+
         public void SetAltPressed(bool value)
         {
             isAltPressed = value;

--- a/src/ScottPlot.Avalonia/AvaPlotBackend.cs
+++ b/src/ScottPlot.Avalonia/AvaPlotBackend.cs
@@ -35,13 +35,13 @@ namespace ScottPlot.Avalonia
             {
                 // hide the version info
                 mainGrid.RowDefinitions[0].Height = new GridLength(0);
-                CanvasSizeChanged((int)(view.Find<Canvas>("canvasPlot").Bounds.Width * dpiScaleOutput), (int)(view.Find<Canvas>("canvasPlot").Bounds.Height * dpiScaleOutput));
                 //dpiScaleInput = settings.gfxFigure.DpiX / 96; THIS IS ONLY NECESSARY ON WPF
                 dpiScaleOutput = settings.gfxFigure.DpiX / 96;
                 view.Find<StackPanel>("canvasDesigner").Background = view.transparentBrush;
-                view.Find<Canvas>("canvasPlot").Background = view.transparentBrush;
+                var canvasPlot = view.Find<Canvas>("canvasPlot");
+                canvasPlot.Background = view.transparentBrush;
+                CanvasSizeChanged((int)(canvasPlot.Bounds.Width * dpiScaleOutput), (int)(canvasPlot.Bounds.Height * dpiScaleOutput));
             }
-
         }
 
         public void SetAltPressed(bool value)

--- a/src/ScottPlot.Demo.Avalonia/CookbookWindow.axaml.cs
+++ b/src/ScottPlot.Demo.Avalonia/CookbookWindow.axaml.cs
@@ -47,8 +47,14 @@ namespace ScottPlot.Demo.Avalonia
         private void LoadTreeWithDemos()
         {
             TreeView DemoTreeview = this.Find<TreeView>("DemoTreeview");
-            DemoTreeview.Items = Reflection.GetPlotNodeItems();
-            DemoTreeview.Focus();
+            var demos = Reflection.GetPlotNodeItems();
+            DemoTreeview.Items = demos;
+
+            CookbookControl DemoPlotControl1 = this.Find<CookbookControl>("DemoPlotControl1");
+            var AboutControl1 = this.Find<AboutControl>("AboutControl1");
+            DemoPlotControl1.IsVisible = true;
+            AboutControl1.IsVisible = false;
+            DemoPlotControl1.LoadDemo(demos[0].Items[0].Items[0].Tag);
         }
     }
 }


### PR DESCRIPTION
**Purpose:**
Cookbook demo work nice, you just forget resize the plot on new demo load.

Additional load first demo on cookbook launch. 
Spent a few hours to understand why the SelectedNode does not change when the TreeView is filled, as a result, I stupidly hardcoded the loading of the first demo upon initialization.
